### PR TITLE
Update dependency name in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The [C implementation (freetds)](https://www.freetds.org/), the [ the Java imple
 
    ```yaml
    dependencies:
-     crystal-tds:
+     tds:
        github: wonderix/crystal-tds
    ```
 


### PR DESCRIPTION
Otherwise you get `Error shard name (tds) doesn't match dependency name (crystal-tds)`