### PR TITLE
Update to support crystal-db 0.12.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,13 +1,14 @@
 name: tds
-version: 0.1.0
+version: 0.2.0
 
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0
+    version: ~> 0.12.0
 
 authors:
   - Ulrich Kramer <ulrich.kramer@web.de>
+  - Lachlan Dowding <lachlan@permafrost.space>
 
 crystal: ">= 1.0.0, < 2.0.0"
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,8 @@ version: 0.2.0
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.12.0
+    #version: ~> 0.12.0
+    commit: a527cfdc4edf7e27d3d7e90ac4d6bc80c8800ba4
 
 authors:
   - Ulrich Kramer <ulrich.kramer@web.de>

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,10 +1,13 @@
 require "spec"
 require "../src/tds"
 
-def connect(uri)
+def connect(connection_string)
   timeout = Time::Span.new(seconds: 60)
   expiry = Time.local + timeout
-  uri = "#{uri}?connect_timeout=#{(timeout/5).seconds}"
+
+  uri = URI.parse connection_string
+  uri.query_params["connect_timeout"] = "#{(timeout/5).seconds}"
+
   while true
     begin
       return DB.open(uri)
@@ -23,9 +26,9 @@ USER = ENV["MSSQL_USER"]? || "sa"
 PASSWORD = ENV["MSSQL_PASSWORD"]? || "My-Secret-Pass"
 DATABASE_NAME = "test"
 
-DATABASE_URI = "tds://#{USER}:#{PASSWORD}@#{HOST}:#{PORT}/#{DATABASE_NAME}"
+DATABASE_URI = "tds://#{USER}:#{PASSWORD}@#{HOST}:#{PORT}/#{DATABASE_NAME}?isolation_level=SNAPSHOT"
 
-MASTER = connect(DATABASE_URI.sub("/#{DATABASE_NAME}", "?"))
+MASTER = connect(DATABASE_URI.sub("/#{DATABASE_NAME}", ""))
 begin
   MASTER.exec("CREATE DATABASE #{DATABASE_NAME}")
 rescue exc : DB::Error

--- a/spec/tds_connection_spec.cr
+++ b/spec/tds_connection_spec.cr
@@ -3,23 +3,23 @@ require "big"
 
 describe TDS::Connection do
   it "connects" do
-    DB.open URL do |db|
+    DB.open DATABASE_URI do |db|
     end
   end
-  it "raises DB::ConnectionRefused" do
-    expect_raises(DB::ConnectionRefused) do
-      DB.open "tds://sa:wrong-password@#{HOSTNAME}:1433" do |db|
+  it "raises DB::Error" do
+    expect_raises(DB::Error) do
+      DB.open "tds://#{USER}:#{PASSWORD + "XYZ"}@#{HOST}:#{PORT}" do |db|
       end
     end
   end
   it "raises DB::ConnectionRefused" do
     expect_raises(DB::ConnectionRefused) do
-      DB.open "tds://#{HOSTNAME}:5555" do |db|
+      DB.open "tds://#{HOST}:65535" do |db|
       end
     end
   end
   it "prepare statement" do
-    connection = DB.connect(URL).as(TDS::Connection)
+    connection = DB.connect(DATABASE_URI).as(TDS::Connection)
     connection.sp_prepare("@P0 int", "SELECT c1 FROM TEST WHERE c1 =  @P0 ").should eq 1
     connection.close
   end

--- a/spec/tds_db_spec.cr
+++ b/spec/tds_db_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 require "db/spec"
 
 DB::DriverSpecs(DB::Any).run do
-  connection_string URL
+  connection_string DATABASE_URI
 
   before do
   end

--- a/spec/tds_transaction_spec.cr
+++ b/spec/tds_transaction_spec.cr
@@ -3,14 +3,14 @@ require "big"
 
 describe DB::Transaction do
   it "commit is working" do
-    DB.open URL do |db|
+    DB.open DATABASE_URI do |db|
       db.transaction do |tx|
         cnn = tx.connection
       end
     end
   end
   it "rollback is working" do
-    DB.open URL do |db|
+    DB.open DATABASE_URI do |db|
       db.transaction do |tx|
         cnn = tx.connection
         tx.rollback

--- a/src/tds/connection.cr
+++ b/src/tds/connection.cr
@@ -21,7 +21,7 @@ class TDS::Connection < DB::Connection
       database_name = File.basename(uri.path || "/")
       connect_timeout = params.has_key?("connect_timeout") ? Time::Span.new(seconds: params["connect_timeout"].to_i) : nil
       read_timeout = Time::Span.new(seconds: params.fetch("read_timeout", "30").to_i)
-      isolation_level = params["isolation_level"]? || "SNAPSHOT"
+      isolation_level = params["isolation_level"]?
 
       Options.new(host: host, port: port, user: user, password: password, database_name: database_name, connect_timeout: connect_timeout, read_timeout: read_timeout, isolation_level: isolation_level)
     end
@@ -59,7 +59,7 @@ class TDS::Connection < DB::Connection
     else
       raise ::Exception.new("Unsupported version #{@version}")
     end
-    self.perform_exec "SET TRANSACTION ISOLATION LEVEL #{tds_options.isolation_level}"
+    self.perform_exec "SET TRANSACTION ISOLATION LEVEL #{tds_options.isolation_level}" if tds_options.isolation_level
   end
 
   def send(type : PacketIO::Type, &block : IO ->)

--- a/src/tds/driver.cr
+++ b/src/tds/driver.cr
@@ -1,6 +1,16 @@
 class TDS::Driver < DB::Driver
-  def build_connection(context : DB::ConnectionContext) : TDS::Connection
-    TDS::Connection.new(context)
+  class TDS::ConnectionBuilder < DB::ConnectionBuilder
+    def initialize(@options : DB::Connection::Options, @tds_options : TDS::Connection::Options)
+    end
+
+    def build : DB::Connection
+      TDS::Connection.new(@options, @tds_options)
+  end
+end
+
+  def connection_builder(uri : URI) : DB::ConnectionBuilder
+    params = HTTP::Params.parse(uri.query || "")
+    ConnectionBuilder.new(connection_options(params), TDS::Connection::Options.from_uri(uri))
   end
 end
 

--- a/src/tds/errno.cr
+++ b/src/tds/errno.cr
@@ -11,6 +11,9 @@ module TDS
   EROLLBACK =   3903 # The ROLLBACK TRANSACTION request has no corresponding BEGIN TRANSACTION
 
   class ProtocolError < DB::Error
+    def initialize(msg = "")
+      super(msg)
+    end
   end
 
   class ServerError < DB::Error

--- a/src/tds/packet_io.cr
+++ b/src/tds/packet_io.cr
@@ -68,7 +68,8 @@ class TDS::PacketIO < IO
         raise ProtocolError.new("Unexpected end of file") if count == 0
         @write_pos += count
       end
-      raise ProtocolError.new if Type.new(Int32.new(@buffer[0])) != @type
+      received_type = Type.new(Int32.new(@buffer[0]))
+      raise ProtocolError.new("Unexpected packet type received: expected type #{@type}, received type #{received_type}") if received_type != @type
       last_pos = Int32.new(NETWORK_ENCODING.decode(UInt16, @buffer[2, 2]))
       @last = @buffer[1] == 1_u8
       while @write_pos < last_pos


### PR DESCRIPTION
There was a breaking change to how connections get created introduced in crystal-db 0.12.0: https://github.com/crystal-lang/crystal-db/pull/181.

This pull request updates crystal-tds to work with crystal-db 0.12.0.

Also, I changed how isolation levels are handled. Since not all databases have SNAPSHOT isolation enabled, and not all logins have the privilege to enable it, I have removed SNAPSHOT from being set by default on new connections. Doing this means that crystal-tds can be used for databases that don't have SNAPSHOT allowed (I have some databases without SNAPSHOT enabled that I'd like to use crystal-tds for, I do not own nor have the rights to change settings on these databases).

To allow isolation level to set as required, there is a new connection string URI query parameter `isolation_level` added, which when specified will set the given isolation level on new connections.

Removing the default SNAPSHOT isolation level then caused the driver spec transaction tests to fail. So to work around the crystal-db driver spec transactional tests requiring SNAPSHOT isolation to work,  I updated the spec test DB connection string to include the query parameter `isolation_level=SNAPSHOT` and the driver specs transaction tests now pass again, with one caveat: I had to fix the crystal-db driver specs to support query params on the test DB connection string. 

My pull request to fix the driver specs has been merged into crystal-db (https://github.com/crystal-lang/crystal-db/commit/a527cfdc4edf7e27d3d7e90ac4d6bc80c8800ba4), so for now I've temporarily specified the relevant commit sha as the required version of the crystal-db shard. Once a new version of crystal-db is released/tagged, we can update `shard.yml` to depend on that version when that time comes.

Thanks for your consideration.