### PR TITLE
Fix indentation in `TDS::Driver` class

### DIFF
--- a/src/tds/driver.cr
+++ b/src/tds/driver.cr
@@ -5,8 +5,8 @@ class TDS::Driver < DB::Driver
 
     def build : DB::Connection
       TDS::Connection.new(@options, @tds_options)
+    end
   end
-end
 
   def connection_builder(uri : URI) : DB::ConnectionBuilder
     params = HTTP::Params.parse(uri.query || "")


### PR DESCRIPTION
@wonderix sorry about this, but I noticed my previous change screwed up the indentation in the `TDS::Driver` class, so this pull request fixes that small mistake on my part.