### PR TITLE
Add support for TDS `ORDER` token used when a query includes an `ORDER BY` statement

### DIFF
--- a/src/tds/prepared_statement.cr
+++ b/src/tds/prepared_statement.cr
@@ -17,10 +17,10 @@ class TDS::PreparedStatement < DB::Statement
         index += 1
         PreparedStatement.encode(args[index])
       rescue ::IndexError
-        raise DB::Error.new("To few arguments for statement #{command}")
+        raise DB::Error.new("Too few arguments specified for statement: #{command}")
       end
     end
-    raise DB::Error.new("To much arguments for statement #{command}") if index != args.size - 1
+    raise DB::Error.new("Too many arguments specified for statement: #{command}") if index != args.size - 1
     cmd
   end
 
@@ -38,10 +38,10 @@ class TDS::PreparedStatement < DB::Statement
         params << "#{param} #{type_info.type}"
         param
       rescue ::IndexError
-        raise DB::Error.new("To few arguments for statement #{command}")
+        raise DB::Error.new("Too few arguments specified for statement: #{command}")
       end
     end
-    raise DB::Error.new("To much arguments for statement #{command}") if index != args.size - 1
+    raise DB::Error.new("Too many arguments specified for statement: #{command}") if index != args.size - 1
     @proc_id = Parameter.new(connection.sp_prepare(params.join(","), cmd))
   end
 

--- a/src/tds/token.cr
+++ b/src/tds/token.cr
@@ -179,7 +179,15 @@ module TDS::Token
     end
   end
 
-  alias Token = InfoOrError | MetaData | LogInAck | Row | Done | DoneInProc | EnvChange | ReturnStatus | Param
+  struct Order
+    def self.from_io(io : IO)
+      len = UInt16.from_io(io, ENCODING)
+      io.seek(len, IO::Seek::Current)
+      Order.new
+    end
+  end
+
+  alias Token = InfoOrError | MetaData | LogInAck | Row | Done | DoneInProc | EnvChange | ReturnStatus | Param | Order
 
   private class Iterator
     include ::Iterator(Token)
@@ -224,6 +232,8 @@ module TDS::Token
           ReturnStatus.from_io(@io)
         when Type::PARAM
           Param.from_io(@io)
+        when Type::ORDER
+          Order.from_io(@io)
         else
           raise ProtocolError.new("Invalid token #{"0x%02x" % type} at position #{"0x%04x" % @io.pos}")
         end


### PR DESCRIPTION
@wonderix this pull request adds support for the TDS token `ORDER`, which fixes an issue where the driver raises an error for an invalid token 0xa9 whenever a query includes an `ORDER BY`, and fixes a few typos in some error messages. Thanks for your consideration!