### PR TITLE
Fix `TDS::Connection#sp_prepare` to support `Order` token

### DIFF
--- a/src/tds/connection.cr
+++ b/src/tds/connection.cr
@@ -89,6 +89,7 @@ class TDS::Connection < DB::Connection
         Token.each(io) do |token|
           case token
           when Token::MetaData
+          when Token::Order
           when Token::ReturnStatus
           when Token::DoneInProc
           when Token::Param


### PR DESCRIPTION
@wonderix it turns out my previous pull request to add support for ORDER BY clauses missed the list of expected tokens in `TDS::Connection#sp_prepare`. As a result, I was getting the following error when trying to prepare a SQL statement with an ORDER BY. This pull request fixes this issue so that SQL statements with ORDER BY clauses can be prepared without error:

```
Unexpected token TDS::Token::Order() while preparing "...ORDER BY 1" (DB::Error)
  from lib\tds\src\tds\connection.cr:102 in 'sp_prepare'
  from lib\tds\src\tds\connection.cr:77 in 'sp_prepare'
  from lib\tds\src\tds\prepared_statement.cr:45 in 'ensure_prepared'
  from lib\tds\src\tds\prepared_statement.cr:51 in 'perform_query'
  from lib\db\src\db\statement.cr:93 in 'perform_query_with_rescue'
  from lib\db\src\db\statement.cr:80 in 'query:args'
  from lib\db\src\db\pool_statement.cr:29 in 'query:args'
  from lib\db\src\db\query_methods.cr:46 in 'query:args'
  from lib\db\src\db\query_methods.cr:61 in 'since'
```