### PR TITLE
Raise `DB::ConnectionLost` error when an IO error occurs to enable the crystal-db database pool to automatically remove bad connections from the connection pool

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ dependencies:
   db:
     github: crystal-lang/crystal-db
     #version: ~> 0.12.0
-    commit: a527cfdc4edf7e27d3d7e90ac4d6bc80c8800ba4
+    commit: 06df272740fb9141050681ae916c465cc8e70584
 
 authors:
   - Ulrich Kramer <ulrich.kramer@web.de>

--- a/src/tds.cr
+++ b/src/tds.cr
@@ -2,5 +2,5 @@ require "db"
 require "./tds/**"
 
 module TDS
-  VERSION = "0.1.0"
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify.downcase }}
 end

--- a/src/tds/result_set.cr
+++ b/src/tds/result_set.cr
@@ -31,9 +31,12 @@ class TDS::ResultSet < DB::ResultSet
     while !@done
       token = begin
         @iterator.next
-      rescue exc : ::Exception
+      rescue ex : IO::Error
         @done = true
-        raise DB::Error.new("#{exc.to_s} in \"#{statement.command}\"")
+        raise DB::ConnectionLost.new(statement.connection, ex)
+      rescue ex
+        @done = true
+        raise DB::Error.new("#{ex.to_s} in \"#{statement.command}\"", ex)
       end
       case token
       when Token::Row

--- a/src/tds/type_info.cr
+++ b/src/tds/type_info.cr
@@ -157,7 +157,7 @@ module TDS
       when Nil
         NVarchar.new(1)
       else
-        raise NotImplemented.new("Invalid type #{value.inspect}")
+        raise NotImplemented.new("Unsupported value : #{value.class} = #{value.inspect} (expected type: String | Int8 | Int16 | Int32 | Int64 | Float32 | Float64 | Time | BigDecimal | Nil)")
       end
     end
   end
@@ -252,7 +252,7 @@ module TDS
           ENCODING.encode(value.to_i64, io)
         end
       else
-        raise ProtocolError.new("Unsupported value #{value}")
+        raise ProtocolError.new("Unsupported value : #{value.class} = #{value.inspect} (expected type: Number | Nil)")
       end
     end
 
@@ -389,7 +389,7 @@ module TDS
         ENCODING.encode(0x1_u8, io)
         ENCODING.encode(value.to_u8.bit(0), io)
       else
-        raise ProtocolError.new("Unsupported value #{value}")
+        raise ProtocolError.new("Unsupported value : #{value.class} = #{value.inspect} (expected type: Number | Nil)")
       end
     end
 
@@ -467,7 +467,7 @@ module TDS
           ENCODING.encode(value.to_f64, io)
         end
       else
-        raise ProtocolError.new("Unsupported value #{value}")
+        raise ProtocolError.new("Unsupported value : #{value.class} = #{value.inspect} (expected type: Number | Nil)")
       end
     end
 
@@ -559,7 +559,7 @@ module TDS
         ENCODING.encode(days, io)
         ENCODING.encode(fraction, io)
       else
-        raise ProtocolError.new("Unsupported value #{value}")
+        raise ProtocolError.new("Unsupported value : #{value.class} = #{value.inspect} (expected type: Time | Nil)")
       end
     end
 
@@ -622,7 +622,7 @@ module TDS
         ENCODING.encode(sign, io)
         io.write(data.to_slice)
       else
-        raise ProtocolError.new("Unsupported value #{value}")
+        raise ProtocolError.new("Unsupported value : #{value.class} = #{value.inspect} (expected type: BigDecimal | Nil)")
       end
     end
 
@@ -678,7 +678,7 @@ module TDS
         ENCODING.encode(UInt16.new(value.size * 2), io)
         UTF16_IO.write(io, value, ENCODING)
       else
-        raise ProtocolError.new("Unsupported value #{value}")
+        raise ProtocolError.new("Unsupported value : #{value.class} = #{value.inspect} (expected type: String | Nil)")
       end
     end
 


### PR DESCRIPTION
@wonderix This pull request changes the TDS driver to raise a `DB:ConnectionLost` error if an IO error occurs when reading or writing to the socket, which then closes the connection (because it's gone bad likely because the SQL Server or a firewall reset the connection without telling the client), and this makes sure the connection is removed from the crystal-db connection pool. Currently the bad TDS connection is put back in the pool and handed out again on the next borrow, which means the pool won't self heal and the bad connection will stall the application using the driver.

I also changed how the `TDS::VERSION` constant is set to use a macro which calls the `shards version` command to make sure the version aligns between the shard.yml and the code, because I noticed I previously forgot to update the code version when I updated the shard.yml version. This fixes that so we only ever have to update the shard.yml version and the code version will stay in sync.

And I also added a more detail to a lot of the other error messages to help with diagnosing issues, and if we are wrapping another exception then I add that as the cause when raising.

Thanks for your consideration!