### PR TITLE
Fix `TDS::ProtocolError` raised when non-nil non-String argument is provided when executing a statement that was prepared with that argument set to nil

### DIFF
--- a/spec/tds_statement_spec.cr
+++ b/spec/tds_statement_spec.cr
@@ -10,4 +10,14 @@ describe TDS::PreparedStatement do
   it "handles SELECT" do
     DATABASE.query_one "SELECT CAST(c1 as INT) FROM TEST WHERE c1 = ?", 1 { |rs| rs.read(Int32) }.should eq 1
   end
+  it "handles ORDER BY" do
+    DATABASE.query_one "SELECT CAST(c1 as INT) FROM TEST WHERE c1 = ? ORDER BY 1", 1 { |rs| rs.read(Int32) }.should eq 1
+  end
+  it "should not raise exception when prepared on first execution with nil argument then later executed with non-nil argument" do
+    DATABASE.using_connection do |connection|
+      statement = TDS::PreparedStatement.new(connection, "SELECT CAST(c1 as INT) FROM TEST WHERE c1 = ?")
+      statement.query nil
+      statement.query 1
+    end
+  end
 end

--- a/spec/tds_type_info_spec.cr
+++ b/spec/tds_type_info_spec.cr
@@ -31,6 +31,13 @@ describe TDS::TypeInfo do
       test_encoding(TDS::Int_n.new(8), nil)
     end
   end
+  describe TDS::Bit_n do
+    it "encodes and decodes correct" do
+      test_encoding(TDS::Bit_n.new(1), 0)
+      test_encoding(TDS::Bit_n.new(1), 1)
+      test_encoding(TDS::Bit_n.new(0), nil)
+    end
+  end
   describe TDS::Flt_n do
     it "encodes and decodes correct" do
       test_encoding(TDS::Flt_n.new(4), 1.0)

--- a/src/tds/rpc_request.cr
+++ b/src/tds/rpc_request.cr
@@ -7,7 +7,8 @@ module TDS
       BY_REFERENCE  = 0x01
       DEFAULT_VALUE = 0x02
     end
-    @type_info : TypeInfo
+
+    getter value : Value, type_info : TypeInfo, name : String, status : Status
 
     def initialize(@value : Value, type_info : TypeInfo? = nil, @name = "", @status = Status.new(0))
       @type_info = type_info || TypeInfo.from_value(@value)
@@ -26,8 +27,9 @@ module TDS
     PROCEDURE_NAME_LENGTH = 0xffff_u16
 
     enum Type
-      EXECUTE = 12
-      PREPARE = 11
+      EXECUTE   = 12
+      PREPARE   = 11
+      UNPREPARE = 15
     end
 
     def initialize(@id : Type, @parameters : Array(Parameter), @options = 0_u16)


### PR DESCRIPTION
If a statement happens to be initially prepared with a nil argument then that argument type is [inferred to be NVARCHAR ](https://github.com/wonderix/crystal-tds/blob/bedde713c7f4ade6b7a28511c53f0fe4bc302864/src/tds/type_info.cr#L158) and the type is [cached](https://github.com/wonderix/crystal-tds/blob/bedde713c7f4ade6b7a28511c53f0fe4bc302864/src/tds/prepared_statement.cr#L37). Later when the statement is executed with a non-nil non-String argument, an exception is raised that the argument value is not supported because it is expecting the cached NVARCHAR type (previously inferred from nil) even though the actual argument and column type could be anything. If the type is a non-*CHAR type, then the following exception is raised:

    Unsupported value : <Class> = <Value> (expected type: String | Nil) (TDS::ProtocolError)

This change fixes this issue by caching the prepared statement handles against the unique combination of inferred types, and then fetching the relevant handle using the inferred types of the given arguments at statement execution time.

Prepared statements are now also unprepared when the statement is closed to clean up the database-side resources gracefully.