### PR TITLE
Fix Crystal 1.14.0 compilation error `undefined constant ConnectionBuilder`

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,7 +13,7 @@ def connect(connection_string)
       return DB.open(uri)
     rescue exc : DB::ConnectionRefused
       raise exc if Time.local > expiry
-      sleep(5)
+      sleep(5.seconds)
     end
   end
 end

--- a/src/tds/driver.cr
+++ b/src/tds/driver.cr
@@ -1,5 +1,5 @@
 class TDS::Driver < DB::Driver
-  class TDS::ConnectionBuilder < DB::ConnectionBuilder
+  class ConnectionBuilder < DB::ConnectionBuilder
     def initialize(@options : DB::Connection::Options, @tds_options : TDS::Connection::Options)
     end
 
@@ -10,7 +10,7 @@ class TDS::Driver < DB::Driver
 
   def connection_builder(uri : URI) : DB::ConnectionBuilder
     params = HTTP::Params.parse(uri.query || "")
-    ConnectionBuilder.new(connection_options(params), TDS::Connection::Options.from_uri(uri))
+    TDS::Driver::ConnectionBuilder.new(connection_options(params), TDS::Connection::Options.from_uri(uri))
   end
 end
 


### PR DESCRIPTION
Compiling the TDS driver with Crystal v1.14.0 results in the following error:

    C:\crystal-tds>crystal spec
    Showing last frame. Use --error-trace for full trace.

    In src\tds\driver.cr:13:5

     13 | ConnectionBuilder.new(connection_options(params), TDS::Connection::Options.from_uri(uri))
          ^----------------
    Error: undefined constant ConnectionBuilder

The `ConnectionBuilder` class had inadvertently been declared with an extra `TDS` level in its namespace by mistake:

    TDS::Driver::TDS::ConnectionBuilder

Then it was later referred to using `TDS::ConnectionBuilder` which somehow worked on previous versions of the compiler.

This fix removes the extra `TDS` level from the `ConnectionBuilder` namespace, as this was a typo, and changes references to use the fully-qualified name `TDS::Driver::ConnectionBuilder`.

Also fixes the compilation warning that `sleep(Number)` is deprecated by replacing the calls with `sleep(Time::Span)` instead.