### PR TITLE
Fixes `PreparedStatement` and `UnpreparedStatement` handling of parameter placeholders

### DIFF
--- a/spec/tds_statement_spec.cr
+++ b/spec/tds_statement_spec.cr
@@ -1,5 +1,18 @@
 require "./spec_helper"
 
+describe TDS::UnpreparedStatement do
+  it "handles parameters" do
+    DATABASE.using_connection do |connection|
+      statement = TDS::UnpreparedStatement.new(connection, "SELECT CAST(c1 as INT) FROM TEST WHERE c1 = ?")
+      statement.query(1) do |rs|
+        rs.each do
+          rs.read(Int32).should eq 1
+        end
+      end
+    end
+  end
+end
+
 describe TDS::PreparedStatement do
   it "handles ints" do
     DATABASE.query_one "SELECT CAST(? as INT)", 1 { |rs| rs.read(Int32) }.should eq 1
@@ -19,5 +32,52 @@ describe TDS::PreparedStatement do
       statement.query nil
       statement.query 1
     end
+  end
+  it "handles query with question mark parameter and quoted string including a question mark" do
+    DATABASE.query_one "SELECT 1 WHERE ? LIKE '%?'", "Wherefore art thou?" { |rs| rs.read(Int32) }.should eq 1
+  end
+  it "handles query with quoted values and comments that contain parameter like tokens" do
+    statement = <<-SQL
+    -- comment with ? and @p1 and @test
+    DECLARE @namedparam INT = 1
+    SELECT CAST(c1 as INT) -- another comment with ? and @p1 and @test
+    FROM TEST
+    WHERE c1 = ?
+    /* multi-line (1/2) comment with ? and @p1 and @test
+       multi-line (2/2) comment with ? and @p1 and @test
+    */
+    OR c1 LIKE '%?'
+    OR @namedparam = ?
+    OR c1 = '' /* another comment with ? and @p1 and @test */
+    SQL
+
+    DATABASE.query_one statement, 1, 1 { |rs| rs.read(Int32) }.should eq 1
+  end
+
+  it "handles query with $1 parameter" do
+    DATABASE.query_one "SELECT 1 WHERE $1 LIKE '$%'", "$1,000.00" { |rs| rs.read(Int32) }.should eq 1
+  end
+  it "handles query with multiple $-prefixed parameters" do
+    DATABASE.query_one "SELECT CAST(c1 as INT) FROM TEST WHERE c1 = $1 OR c1 = $2", 1, 2 { |rs| rs.read(Int32) }.should eq 1
+  end
+  it "handles query with reused $-prefixed parameters" do
+    DATABASE.query_one "SELECT $2 FROM TEST WHERE c1 = $1 OR c1 = $2", 1, 2 { |rs| rs.read(Int32) }.should eq 2
+  end
+  it "raises when query mixes use of ? and $-prefixed parameters" do
+    expect_raises(DB::Error, "Mixed use of parameter placeholders") do
+      DATABASE.query_one "SELECT $2 FROM TEST WHERE c1 = $1 OR c1 = $2 OR $2 = ?", 1, 2, 3 { |rs| rs.read(Int32) }.should eq 2
+    end
+  end
+  it "handles query with escaped single quote in single-quoted literal" do
+    DATABASE.query_one "SELECT 1 WHERE $1 LIKE '''a%'", "'abc'" { |rs| rs.read(Int32) }.should eq 1
+  end
+  it "handles query with escaped double quote in double-quoted literal" do
+    DATABASE.query_one "SET QUOTED_IDENTIFIER OFF; SELECT 1 WHERE $1 LIKE \"\"\"a%\"", "\"abc" { |rs| rs.read(Int32) }.should eq 1
+  end
+  it "handles query with double-quoted identifier" do
+    DATABASE.query_one "SET QUOTED_IDENTIFIER ON; SELECT 1 FROM \"TEST\"" { |rs| rs.read(Int32) }.should eq 1
+  end
+  it "handles query with escaped right bracket in bracket-quoted identifier" do
+    DATABASE.query_one "SELECT CAST([TEST[]]].c1 AS INT) FROM TEST AS [TEST[]]] WHERE c1 = $1", 1 { |rs| rs.read(Int32) }.should eq 1
   end
 end

--- a/src/tds/connection.cr
+++ b/src/tds/connection.cr
@@ -143,11 +143,7 @@ class TDS::Connection < DB::Connection
   end
 
   def build_prepared_statement(query) : DB::Statement
-    if query.includes?('?')
-      PreparedStatement.new(self, query)
-    else
-      UnpreparedStatement.new(self, query)
-    end
+    PreparedStatement.new(self, query)
   end
 
   def build_unprepared_statement(query) : DB::Statement

--- a/src/tds/rpc_request.cr
+++ b/src/tds/rpc_request.cr
@@ -27,9 +27,10 @@ module TDS
     PROCEDURE_NAME_LENGTH = 0xffff_u16
 
     enum Type
-      EXECUTE   = 12
-      PREPARE   = 11
-      UNPREPARE = 15
+      EXECUTESQL = 10
+      EXECUTE    = 12
+      PREPARE    = 11
+      UNPREPARE  = 15
     end
 
     def initialize(@id : Type, @parameters : Array(Parameter), @options = 0_u16)

--- a/src/tds/statement_methods.cr
+++ b/src/tds/statement_methods.cr
@@ -1,0 +1,97 @@
+require "string_scanner"
+require "./type_info"
+require "./utf16_io"
+
+module TDS
+  module StatementMethods
+    abstract def requestType : RpcRequest::Type
+
+    def perform_query(args : Enumerable) : DB::ResultSet
+      statement, parameters = parameterize(args)
+      conn.send(PacketIO::Type::RPC) do |io|
+        RpcRequest.new(id: requestType, parameters: parameters).write(io)
+      end
+      result = nil
+      conn.recv(PacketIO::Type::REPLY) do |io|
+        result = ResultSet.new(self, Token.each(io))
+      end
+      result.not_nil!
+    rescue ex : IO::Error
+      raise DB::ConnectionLost.new(conn, ex)
+    end
+
+    def perform_exec(args : Enumerable) : DB::ExecResult
+      statement, parameters = parameterize(args)
+      conn.send(PacketIO::Type::RPC) do |io|
+        RpcRequest.new(id: requestType, parameters: parameters).write(io)
+      end
+      conn.recv(PacketIO::Type::REPLY) do |io|
+        Token.each(io) { |t| }
+      end
+      DB::ExecResult.new 0, 0
+    rescue ex : IO::Error
+      raise DB::ConnectionLost.new(conn, ex)
+    end
+
+    abstract def parameterize(args : Enumerable) : {String, Array(Parameter)}
+
+    # Replaces `?` placeholders with `@Pn` where n = 0..n placeholders in the
+    # given SQL statement, returning the updated statement, and array of
+    # parameter names and types to be passed to `sp_prepare` or `sp_executesql`
+    def parameterize(command : String, arguments : Array(Parameter)) : {String, Array(String), Array(Parameter)}
+      index, names, parameters, reordered_arguments = 0, Hash(String, String).new, Array(String).new, Array(Parameter).new(arguments.size)
+      unnamed_params_found, named_params_found = false, false
+      statement = String.build(command.size) do |string|
+        scanner = StringScanner.new(command)
+        until scanner.eos?
+          case
+          when value = scanner.scan(/\[([^\]]|\]\])*\]/) # bracket quoted value, including escaped right brackets such as `]]`
+          when value = scanner.scan(/'([^']|'')*'/)      # single quoted value, including escaped single-quotes such as `''`
+          when value = scanner.scan(/"([^"]|"")*"/)      # double quoted value, including escaped double-quotes such as `""`
+          when value = scanner.scan(/--.*/)              # single line comment
+          when comment_start = scanner.scan(/\/\*/)      # multi-line comment
+            if comment_end = scanner.scan(/.*?\*\//m)
+              value = comment_start + comment_end
+            else
+              value = comment_start + scanner.rest
+              scanner.terminate
+            end
+          when unnamed_param = scanner.scan('?') # unnamed parameter placeholder
+            index += 1
+            value = "@PARAM_CRYSTAL_TDS_$#{index}__"
+            parameters << "#{value} #{arguments[index - 1].type_info.type}"
+            unnamed_params_found = true
+          when named_param = scanner.scan(/\$\d+/) # named parameter placeholder
+            if names.has_key? named_param
+              value = names[named_param] # named param already declared, so we can use the saved param name for it
+            else
+              idx = named_param[1..].to_i # use the index in the named param to find the related argument to bind to
+              value = "@PARAM_CRYSTAL_TDS_#{named_param}__"
+              parameters << "#{value} #{arguments[idx - 1].type_info.type}"
+              names[named_param] = value                # save the named param in case its reused later in the query
+              reordered_arguments << arguments[idx - 1] # argument values need to be reordered to match declaration order
+            end
+            named_params_found = true
+          when value = scanner.scan(/./m) # all other tokens
+          else
+            raise DB::Error.new("Unexpected character encountered when parsing statement: #{scanner.peek(1).inspect}")
+          end
+          string << value
+        end
+      end
+
+      raise DB::Error.new("Mixed use of parameter placeholders (?, $n) is not allowed: #{command}") if unnamed_params_found && named_params_found
+      raise DB::Error.new("Too many arguments specified for statement: #{command}") if parameters.size < arguments.size
+
+      reordered_arguments = arguments if unnamed_params_found
+
+      {statement, parameters, reordered_arguments}
+    rescue ex : ::IndexError
+      raise DB::Error.new("Too few arguments specified for statement: #{command}", ex)
+    end
+
+    def conn
+      @connection.as(Connection)
+    end
+  end
+end

--- a/src/tds/unprepared_statement.cr
+++ b/src/tds/unprepared_statement.cr
@@ -1,75 +1,23 @@
-require "./utf16_io"
-require "./type_info"
+require "./statement_methods"
 
 class TDS::UnpreparedStatement < DB::Statement
+  include StatementMethods
+
   def initialize(connection, command)
     super(connection, command)
   end
 
-  private def expanded_command(e : Enumerable)
-    args = e.to_a
-    index = -1
-    cmd = command.gsub(/\?/) do |s|
-      begin
-        index += 1
-        UnpreparedStatement.encode(args[index])
-      rescue ::IndexError
-        raise DB::Error.new("Too few arguments for statement #{command}")
-      end
-    end
-    raise DB::Error.new("Too many arguments for statement #{command}") if index != args.size - 1
-    cmd
+  protected def requestType : RpcRequest::Type
+    RpcRequest::Type::EXECUTESQL
   end
 
-  protected def perform_query(args : Enumerable) : DB::ResultSet
-    conn.send(PacketIO::Type::QUERY) do |io|
-      UTF16_IO.write(io, expanded_command(args), ENCODING)
-    end
-    result = nil
-    conn.recv(PacketIO::Type::REPLY) do |io|
-      result = ResultSet.new(self, Token.each(io))
-    end
-    result.not_nil!
-  rescue ex : IO::Error
-    raise DB::ConnectionLost.new(conn, ex)
-  end
-
-  protected def perform_exec(args : Enumerable) : DB::ExecResult
-    statement = expanded_command(args)
-    conn.send(PacketIO::Type::QUERY) do |io|
-      UTF16_IO.write(io, statement, ENCODING)
-    end
-    conn.recv(PacketIO::Type::REPLY) do |io|
-      Token.each(io) { |t| }
-    end
-    DB::ExecResult.new 0, 0
-  rescue ex : IO::Error
-    raise DB::ConnectionLost.new(conn, ex)
-  rescue ex
-    raise StatementError.new(ex, statement.to_s)
+  protected def parameterize(args : Enumerable) : {String, Array(Parameter)}
+    arguments = args.to_a.map { |arg| Parameter.new(arg).as(Parameter) }
+    statement, parameters, arguments = parameterize(command, arguments)
+    {statement, [Parameter.new(statement), Parameter.new(parameters.join(","))] + arguments}
   end
 
   protected def do_close
     super
-  end
-
-  protected def self.encode(value : Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 | Float64 | Float32 | BigDecimal)
-    value.to_s
-  end
-
-  protected def self.encode(value : String)
-    "'#{value.gsub(/'/, "''")}'"
-  end
-
-  protected def self.encode(value : Time)
-    "'#{Time::Format::RFC_3339.format(value)}'"
-  end
-
-  protected def self.encode(value : Nil)
-    "NULL"
-  end
-
-  protected def conn
-    @connection.as(Connection)
   end
 end


### PR DESCRIPTION
Fixes `PreparedStatement` and `UnpreparedStatement` handling of parameter placeholder `?` to correctly support queries using quoted values or comments legitimately containing `?`.

Previously the logic used a naive regular expression match against any occurrence of `?`. The new logic uses a simple query parser which detects and ignores quoted values and comments.

Parameter placeholders `?` are now replaced with `@PARAM_CRYSTAL_TDS_$n__` where n = 0..n for the number of parameters specified in the query. This parameter naming should reduce the possibility of clashes with existing variable declarations in SQL statements.

`UnpreparedStatement` now uses `sp_executesql` to execute queries, allowing for parameter values to be bound rather than the previous approach of inlining the values which is a SQL injection vector.

Also adds support for `$1` .. `$n` parameter placeholders, which can now be used instead of `?` if desired. Use of `$n` placeholders makes it possible to reuse a parameter in multiple places in a statement. Note that mixing the use of `?` and `$n` within a statement is not allowed and will raise an exception.

Resolves #22