### PR TITLE
Minify SQL statements before prepare/execute to mitigate 4000 character statement length limit

### DIFF
--- a/spec/tds_statement_spec.cr
+++ b/spec/tds_statement_spec.cr
@@ -108,7 +108,9 @@ describe TDS::PreparedStatement do
     string1 = "this is a multi-\r\n  line string\r\nthat should be\r\nsupported?\r\n"
     string2 = "this is another multi-\r\n  line string\r\nthat should be\r\nsupported?\r\n"
     statement = <<-SQL
-    SET QUOTED_IDENTIFIER OFF;
+
+
+       \t\tSET QUOTED_IDENTIFIER OFF;
 
     DECLARE @string1 NVARCHAR(MAX) = '#{string1}'
     DECLARE @string2 NVARCHAR(MAX) = "#{string2}"
@@ -124,9 +126,16 @@ describe TDS::PreparedStatement do
 
       FROM TEST
 
-     WHERE @string1 = ?
+     WHERE \t\t@string1 = ?
        AND @string2 = ?
        AND c1 = ?
+
+
+            \t\t
+
+            \t
+
+
     SQL
     DATABASE.query_one statement, string1, string2, 1 { |rs| rs.read(String) }.should eq string1
   end

--- a/src/tds/statement_methods.cr
+++ b/src/tds/statement_methods.cr
@@ -35,55 +35,74 @@ module TDS
 
     abstract def parameterize(args : Enumerable) : {String, Array(Parameter)}
 
-    # Replaces `?` placeholders with `@Pn` where n = 0..n placeholders in the
-    # given SQL statement, returning the updated statement, and array of
-    # parameter names and types to be passed to `sp_prepare` or `sp_executesql`
+    # Replaces `?` placeholders with `@P$n__` where n = 0..n placeholders in
+    # the given SQL statement, returning the updated statement, and array of
+    # parameter names and types for `sp_prepare` or `sp_executesql`
     def parameterize(command : String, arguments : Array(Parameter)) : {String, Array(String), Array(Parameter)}
       index, names, parameters, reordered_arguments = 0, Hash(String, String).new, Array(String).new, Array(Parameter).new(arguments.size)
       unnamed_params_found, named_params_found = false, false
+
       statement = String.build(command.size) do |string|
         scanner = StringScanner.new(command)
         until scanner.eos?
           case
-          when value = scanner.scan(/\[([^\]]|\]\])*\]/) # bracket quoted value, including escaped right brackets such as `]]`
-          when value = scanner.scan(/'([^']|'')*'/)      # single quoted value, including escaped single-quotes such as `''`
-          when value = scanner.scan(/"([^"]|"")*"/)      # double quoted value, including escaped double-quotes such as `""`
-          when value = scanner.scan(/--.*/)              # single line comment
-          when comment_start = scanner.scan(/\/\*/)      # multi-line comment
-            if comment_end = scanner.scan(/.*?\*\//m)
-              value = comment_start + comment_end
-            else
-              value = comment_start + scanner.rest
+          when value = scanner.scan(/\[([^\]]|\]\])*\]/m) # bracket quoted value, including escaped right brackets such as `]]`
+            # treat as a literal and do not modify
+          when value = scanner.scan(/'([^']|'')*'/m) # single quoted value, including escaped single-quotes such as `''`
+            # treat as a literal and do not modify
+          when value = scanner.scan(/"([^"]|"")*"/m) # double quoted value, including escaped double-quotes such as `""`
+            # treat as a literal and do not modify
+          when value = scanner.scan(/--.*/) # single line comment
+            # minify statement by removing comments
+            value = ""
+          when comment_start = scanner.scan(/\/\*/) # multi-line comment
+            unless scanner.scan(/.*?\*\//m)
               scanner.terminate
             end
+            # minify statement by removing comments
+            value = ""
           when unnamed_param = scanner.scan('?') # unnamed parameter placeholder
             index += 1
-            value = "@PARAM_CRYSTAL_TDS_$#{index}__"
+            value = "@P$#{index}__"
             parameters << value
             unnamed_params_found = true
           when named_param = scanner.scan(/\$\d+/) # named parameter placeholder
             if names.has_key? named_param
-              value = names[named_param] # named param already declared, so we can use the saved param name for it
+              # named param already declared, so we can use the saved param name for it
+              value = names[named_param]
             else
-              idx = named_param[1..].to_i # use the index in the named param to find the related argument to bind to
-              value = "@PARAM_CRYSTAL_TDS_#{named_param}__"
+              # use the index in the named param to find the related argument to bind to
+              idx = named_param[1..].to_i
+              value = "@P#{named_param}__"
               parameters << value
-              names[named_param] = value                # save the named param in case its reused later in the query
-              reordered_arguments << arguments[idx - 1] # argument values need to be reordered to match declaration order
+              # save the named param in case its reused later in the query
+              names[named_param] = value
+              # argument values need to be reordered to match declaration order
+              reordered_arguments << arguments[idx - 1]
             end
             named_params_found = true
+          when value = scanner.scan(/\s+/m) # one or more whitespace characters
+            # replace runs of whitespace characters with either a single newline
+            # if the value includes at least one newline or carriage return, or
+            # with a single space
+            if value.includes?("\n") || value.includes?("\r")
+              value = "\n"
+            else
+              value = " "
+            end
           when value = scanner.scan(/./m) # all other tokens
+            # treat as a literal and do not modify
           else
-            raise DB::Error.new("Unexpected character encountered when parsing: #{scanner.peek(1).inspect} -- query = #{command.inspect}, args = #{arguments.map {|a| a.value}.inspect}")
+            raise DB::Error.new("Unexpected character encountered when parsing: #{scanner.peek(1).inspect} -- query = #{command.inspect}, args = #{arguments.map { |a| a.value }.inspect}")
           end
           string << value
         end
       end
 
-      raise DB::Error.new("Incorrect use of parameter placeholders: using both ? and $n style placeholders within single query not allowed, choose one placeholder style and use only that style within each query -- query = #{command.inspect}, args = #{arguments.map {|a| a.value}.inspect}") if unnamed_params_found && named_params_found
-      raise DB::Error.new("Incorrect number of arguments: expected #{parameters.size}, but received #{arguments.size} -- query = #{command.inspect}, args = #{arguments.map {|a| a.value}.inspect}") if parameters.size != arguments.size
+      raise DB::Error.new("Incorrect use of parameter placeholders: using both ? and $n style placeholders within single query not allowed, choose one placeholder style and use only that style within each query -- query = #{command.inspect}, args = #{arguments.map { |a| a.value }.inspect}") if unnamed_params_found && named_params_found
+      raise DB::Error.new("Incorrect number of arguments: expected #{parameters.size}, but received #{arguments.size} -- query = #{command.inspect}, args = #{arguments.map { |a| a.value }.inspect}") if parameters.size != arguments.size
 
-      {statement, parameters.map_with_index { |value, i| "#{value} #{arguments[i].type_info.type}" }, unnamed_params_found ? arguments : reordered_arguments}
+      {statement.strip, parameters.map_with_index { |value, i| "#{value} #{arguments[i].type_info.type}" }, unnamed_params_found ? arguments : reordered_arguments}
     end
 
     def conn


### PR DESCRIPTION
I've encountered the following error caused by my SQL statement being > 4000 characters in length, which was exacerbated by the previous change to parameter handling where I naively used quite a long template for the parameter names `@PARAM_CRYSTAL_TDS_$n__` which chews through a lot of characters in statements that have a lot of parameters and reuses them in multiple places:

```
Error 8016: The incoming tabular data stream (TDS) remote procedure call (RPC) protocol stream is incorrect. Parameter 3 (""): Data type 0xE7 has an invalid data length or metadata length. while preparing 

Caused by: Error 8016: The incoming tabular data stream (TDS) remote procedure call (RPC) protocol stream is incorrect. Parameter 3 (""): Data type 0xE7 has an invalid data length or metadata length. (TDS::ServerError)
  from lib\tds\src\tds\token.cr:226 in 'next'
  from lib\tds\src\tds\connection.cr:80 in 'sp_prepare'
  from lib\db\src\db\query_methods.cr:46 in 'query:args'
```

I'm not sure if we can increase the max length of statements that `sp_prepare` will accept. Line https://github.com/wonderix/crystal-tds/blob/ebfe40704819ea6beb7be76d5d0da674a694adbb/src/tds/connection.cr#L85 doesn't specify `type_info` for the statement, so it defaults to the type to `NVARCHAR(4000)` at line https://github.com/wonderix/crystal-tds/blob/ebfe40704819ea6beb7be76d5d0da674a694adbb/src/tds/type_info.cr#L652. I tried specifying a type_info of `NVARCHAR(65536)` on Line https://github.com/wonderix/crystal-tds/blob/ebfe40704819ea6beb7be76d5d0da674a694adbb/src/tds/connection.cr#L85 but that didn't seem to work and the above error was still occurring. 

If the driver supported `NVARCHAR(MAX)` or `NTEXT` then we could use either of these types for the statement with `sp_prepare`, but as far as I can tell these types are not supported, nor have I figured out how to add support for them. @wonderix can you provide guidance on this: do you know if these types are supported or how we would add that support?

As a work around to the this issue, this pull request minifies SQL statements before prepare/execute to attempt to alleviate the 4000 character statement length limit, using the following techniques:
* remove leading and trailing whitespace
* remove comments, single and multi-line
* change parameter names to be shorter `@P$n__`, keeping the double-underscore suffix to reduce likelihood of parameter name clashes with any declared variables